### PR TITLE
修復 Jekyll URL 結構：改用 .html 直接檔案格式

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -51,8 +51,8 @@ linkedin_username:
 
 # Collections - removed to avoid conflicts with numbered directories
 
-# Custom permalink structure 
-permalink: /:path/
+# Custom permalink structure - ensure .html extension
+permalink: /:path.html
 
 # Defaults for different directories
 defaults:
@@ -142,3 +142,10 @@ include:
   - 02_Reading
   - 03_Writing
   - 04_Speaking
+
+# Ensure all markdown files are processed as pages
+plugins:
+  - jekyll-relative-links
+  - jekyll-optional-front-matter
+  - jekyll-default-layout
+  - jekyll-titles-from-headings


### PR DESCRIPTION
- 修改 permalink 從 /:path/ 改為 /:path.html
- 確保所有 markdown 檔案生成 .html 直接檔案而非目錄結構
- 解決 404 錯誤問題